### PR TITLE
Make reuse of forcecrc32 code easier for others, reuse libz's crc32()

### DIFF
--- a/forcing-a-files-crc-to-any-value/forcecrc32.c
+++ b/forcing-a-files-crc-to-any-value/forcecrc32.c
@@ -52,6 +52,8 @@ static int get_degree(uint64_t x);
 uint32_t reverse_crc32(uint32_t delta, uint64_t endDistance)
 {
 	// Compute the change to make
+	delta = reverse_bits(delta);
+
 	delta = (uint32_t)multiply_mod(reciprocal_mod(pow_mod(2, endDistance * 8)), delta);
 
 	delta = reverse_bits(delta);

--- a/forcing-a-files-crc-to-any-value/forcecrc32.c
+++ b/forcing-a-files-crc-to-any-value/forcecrc32.c
@@ -1,6 +1,6 @@
-/* 
+/*
  * CRC-32 forcer (C)
- * 
+ *
  * Copyright (c) 2016 Project Nayuki
  * https://www.nayuki.io/page/forcing-a-files-crc-to-any-value
  *
@@ -11,12 +11,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program (see COPYING.txt).
  * If not, see <http://www.gnu.org/licenses/>.

--- a/forcing-a-files-crc-to-any-value/forcecrc32.c
+++ b/forcing-a-files-crc-to-any-value/forcecrc32.c
@@ -3,7 +3,10 @@
  * 
  * Copyright (c) 2016 Project Nayuki
  * https://www.nayuki.io/page/forcing-a-files-crc-to-any-value
- * 
+ *
+ * Copyright (c) 2016 Elliott Mitchell
+ * Creation of reverse_crc32()
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -26,11 +29,11 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "forcecrc32.h"
+
 
 /* Forward declarations */
 
-static uint32_t get_crc32_and_length(FILE *f, uint64_t *length);
-static void fseek64(FILE *f, uint64_t offset);
 static uint32_t reverse_bits(uint32_t x);
 
 static uint64_t multiply_mod(uint64_t x, uint64_t y);
@@ -40,137 +43,26 @@ static uint64_t reciprocal_mod(uint64_t x);
 static int get_degree(uint64_t x);
 
 
-/* Main program */
+/* Primary entry-point */
 
-int main(int argc, char **argv) {
-	// Handle arguments
-	if (argc != 4) {
-		fprintf(stderr, "Usage: %s FileName ByteOffset NewCrc32Value\n", argv[0]);
-		return EXIT_FAILURE;
-	}
-	
-	// Parse and check file offset argument
-	uint64_t offset;
-	if (sscanf(argv[2], "%" SCNu64, &offset) != 1) {
-		fprintf(stderr, "Error: Invalid byte offset\n");
-		return EXIT_FAILURE;
-	}
-	char temp[21] = {0};
-	sprintf(temp, "%" PRIu64, offset);
-	if (strcmp(temp, argv[2]) != 0) {
-		fprintf(stderr, "Error: Invalid byte offset\n");
-		return EXIT_FAILURE;
-	}
-	
-	// Parse and check new CRC argument
-	uint32_t newcrc;
-	if (strlen(argv[3]) != 8 || argv[3][0] == '+' || argv[3][0] == '-'
-			|| sscanf(argv[3], "%" SCNx32, &newcrc) != 1) {
-		fprintf(stderr, "Error: Invalid new CRC-32 value\n");
-		return EXIT_FAILURE;
-	}
-	newcrc = reverse_bits(newcrc);
-	
-	// Process the file
-	FILE *f = fopen(argv[1], "r+b");
-	if (f == NULL) {
-		perror("fopen");
-		return EXIT_FAILURE;
-	}
-	
-	// Read entire file and calculate original CRC-32 value.
-	// Note: We can't use fseek(f, 0, SEEK_END) + ftell(f) to determine the length of the file, due to undefined behavior.
-	// To be portable, we also avoid using POSIX fseeko()+ftello() or Windows GetFileSizeEx()/_filelength().
-	uint64_t length;
-	uint32_t crc = get_crc32_and_length(f, &length);
-	if (offset > UINT64_MAX - 4 || offset + 4 > length) {
-		fprintf(stderr, "Error: Byte offset plus 4 exceeds file length\n");
-		return EXIT_FAILURE;
-	}
-	fprintf(stdout, "Original CRC-32: %08" PRIX32 "\n", reverse_bits(crc));
-	
+/* to induce a change of "delta" by changing 4 bytes starting endDistance
+* from the end of the data, exclusive-or with the returned value (note,
+* endDistance better be at least 4) */
+
+uint32_t reverse_crc32(uint32_t delta, uint64_t endDistance)
+{
 	// Compute the change to make
-	uint32_t delta = crc ^ newcrc;
-	delta = (uint32_t)multiply_mod(reciprocal_mod(pow_mod(2, (length - offset) * 8)), delta);
-	
-	// Patch 4 bytes in the file
-	fseek64(f, offset);
-	int i;
-	for (i = 0; i < 4; i++) {
-		int b = fgetc(f);
-		if (b == EOF) {
-			perror("fgetc");
-			return EXIT_FAILURE;
-		}
-		b ^= (int)((reverse_bits(delta) >> (i * 8)) & 0xFF);
-		if (fseek(f, -1, SEEK_CUR) != 0) {
-			perror("fseek");
-			return EXIT_FAILURE;
-		}
-		if (fputc(b, f) == EOF) {
-			perror("fputc");
-			return EXIT_FAILURE;
-		}
-	}
-	fprintf(stdout, "Computed and wrote patch\n");
-	
-	// Recheck entire file
-	if (get_crc32_and_length(f, &length) == newcrc) {
-		fprintf(stdout, "New CRC-32 successfully verified\n");
-		fclose(f);
-		return EXIT_SUCCESS;
-	} else {
-		fprintf(stderr, "Error: Failed to update CRC-32 to desired value\n");
-		return EXIT_FAILURE;
-	}
+	delta = (uint32_t)multiply_mod(reciprocal_mod(pow_mod(2, endDistance * 8)), delta);
+
+	delta = reverse_bits(delta);
+
+	return delta;
 }
 
 
 /* Utilities */
 
 static const uint64_t POLYNOMIAL = UINT64_C(0x104C11DB7);  // Generator polynomial. Do not modify, because there are many dependencies
-
-
-static uint32_t get_crc32_and_length(FILE *f, uint64_t *length) {
-	rewind(f);
-	uint32_t crc = UINT32_C(0xFFFFFFFF);
-	*length = 0;
-	while (true) {
-		char buffer[32 * 1024];
-		size_t n = fread(buffer, sizeof(buffer[0]), sizeof(buffer) / sizeof(char), f);
-		if (ferror(f) != 0) {
-			perror("fread");
-			exit(EXIT_FAILURE);
-		}
-		size_t i;
-		for (i = 0; i < n; i++) {
-			int j;
-			for (j = 0; j < 8; j++) {
-				int bit = ((uint8_t)buffer[i] >> j) & 1;
-				crc ^= (uint32_t)bit << 31;
-				int xor = crc >> 31;  // Boolean
-				crc = (crc & UINT32_C(0x7FFFFFFFF)) << 1;
-				if (xor)
-					crc ^= (uint32_t)POLYNOMIAL;
-			}
-		}
-		*length += n;
-		if (feof(f))
-			return ~crc;
-	}
-}
-
-
-static void fseek64(FILE *f, uint64_t offset) {
-	rewind(f);
-	while (offset > 0) {
-		long n = LONG_MAX;
-		if (offset < (unsigned long)n)
-			n = (long)offset;
-		fseek(f, n, SEEK_CUR);
-		offset -= (unsigned long)n;
-	}
-}
 
 
 static uint32_t reverse_bits(uint32_t x) {
@@ -224,7 +116,7 @@ static void divide_and_remainder(uint64_t x, uint64_t y, uint64_t *q, uint64_t *
 		*r = 0;
 		return;
 	}
-	
+
 	int ydeg = get_degree(y);
 	uint64_t z = 0;
 	int i;

--- a/forcing-a-files-crc-to-any-value/forcecrc32.c
+++ b/forcing-a-files-crc-to-any-value/forcecrc32.c
@@ -5,7 +5,7 @@
  * https://www.nayuki.io/page/forcing-a-files-crc-to-any-value
  *
  * Copyright (c) 2016 Elliott Mitchell
- * Creation of reverse_crc32()
+ * Creation of reverse_crc32() and modification of reverse_bits()
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -67,12 +67,14 @@ uint32_t reverse_crc32(uint32_t delta, uint64_t endDistance)
 static const uint64_t POLYNOMIAL = UINT64_C(0x104C11DB7);  // Generator polynomial. Do not modify, because there are many dependencies
 
 
-static uint32_t reverse_bits(uint32_t x) {
-	uint32_t result = 0;
-	int i;
-	for (i = 0; i < 32; i++)
-		result = (result << 1) | ((x >> i) & 1);
-	return result;
+static uint32_t reverse_bits(uint32_t val) {
+	int s;
+	// blitter-type solution, rather faster than the naive solution
+	const uint32_t masks[] = {0x55555555, 0x33333333, 0xF0F0F0F, 0xFF00FF, 0xFFFF};
+	for (s = 0; s<sizeof(masks)/sizeof(masks[0]); ++s)
+		val = ((val >> (1<<s)) & masks[s]) | ((val & masks[s]) << (1<<s));
+
+	return val;
 }
 
 

--- a/forcing-a-files-crc-to-any-value/forcecrc32.h
+++ b/forcing-a-files-crc-to-any-value/forcecrc32.h
@@ -1,0 +1,38 @@
+/* 
+ * CRC-32 forcer (C)
+ * 
+ * Copyright (c) 2016 Project Nayuki
+ * https://www.nayuki.io/page/forcing-a-files-crc-to-any-value
+ *
+ * Copyright (c) 2016 Elliott Mitchell
+ * Creation of this whole header.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program (see COPYING.txt).
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#ifndef _FORCECRC32_H_
+#define _FORCECRC32_H_
+
+#include <stdint.h>
+
+
+/* to induce a change of "delta" by changing 4 bytes starting endDistance
+* from the end of the data, exclusive-or with the returned value (note,
+* endDistance better be at least 4) */
+extern uint32_t reverse_crc32(uint32_t delta, uint64_t endDistance);
+
+#endif
+

--- a/forcing-a-files-crc-to-any-value/forcecrc32.h
+++ b/forcing-a-files-crc-to-any-value/forcecrc32.h
@@ -1,6 +1,6 @@
-/* 
+/*
  * CRC-32 forcer (C)
- * 
+ *
  * Copyright (c) 2016 Project Nayuki
  * https://www.nayuki.io/page/forcing-a-files-crc-to-any-value
  *
@@ -11,12 +11,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program (see COPYING.txt).
  * If not, see <http://www.gnu.org/licenses/>.

--- a/forcing-a-files-crc-to-any-value/forcecrc32.java
+++ b/forcing-a-files-crc-to-any-value/forcecrc32.java
@@ -1,19 +1,19 @@
-/* 
+/*
  * CRC-32 forcer (Java)
- * 
+ *
  * Copyright (c) 2015 Project Nayuki
  * https://www.nayuki.io/page/forcing-a-files-crc-to-any-value
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program (see COPYING.txt).
  * If not, see <http://www.gnu.org/licenses/>.
@@ -26,9 +26,9 @@ import java.io.RandomAccessFile;
 
 
 public class forcecrc32 {
-	
+
 	/* Main function */
-	
+
 	public static void main(String[] args) {
 		String errmsg = main1(args);
 		if (errmsg != null) {
@@ -36,8 +36,8 @@ public class forcecrc32 {
 			System.exit(1);
 		}
 	}
-	
-	
+
+
 	private static String main1(String[] args) {
 		// Handle arguments
 		long offset;
@@ -64,22 +64,22 @@ public class forcecrc32 {
 		File file = new File(args[0]);
 		if (!file.isFile())
 			return "Error: File does not exist: " + file;
-		
+
 		// Process the file
 		try {
 			RandomAccessFile raf = new RandomAccessFile(file, "rws");
 			try {
 				if (offset + 4 > raf.length())
 					return "Error: Byte offset plus 4 exceeds file length";
-				
+
 				// Read entire file and calculate original CRC-32 value
 				int crc = getCrc32(raf);
 				System.out.printf("Original CRC-32: %08X%n", Integer.reverse(crc));
-				
+
 				// Compute the change to make
 				int delta = crc ^ newCrc;
 				delta = (int)multiplyMod(reciprocalMod(powMod(2, (raf.length() - offset) * 8)), delta & 0xFFFFFFFFL);
-				
+
 				// Patch 4 bytes in the file
 				raf.seek(offset);
 				byte[] bytes4 = new byte[4];
@@ -89,13 +89,13 @@ public class forcecrc32 {
 				raf.seek(offset);
 				raf.write(bytes4);
 				System.out.println("Computed and wrote patch");
-				
+
 				// Recheck entire file
 				if (getCrc32(raf) == newCrc)
 					System.out.println("New CRC-32 successfully verified");
 				else
 					return "Error: Failed to update CRC-32 to desired value";
-				
+
 			} catch (IOException e) {
 				return "Error: I/O exception: " + e.getMessage();
 			} finally {
@@ -106,13 +106,13 @@ public class forcecrc32 {
 		}
 		return null;
 	}
-	
-	
+
+
 	/* Utilities */
-	
+
 	private static long POLYNOMIAL = 0x104C11DB7L;  // Generator polynomial. Do not modify, because there are many dependencies
-	
-	
+
+
 	private static int getCrc32(RandomAccessFile raf) throws IOException {
 		raf.seek(0);
 		int crc = 0xFFFFFFFF;
@@ -132,10 +132,10 @@ public class forcecrc32 {
 			}
 		}
 	}
-	
-	
+
+
 	/* Polynomial arithmetic */
-	
+
 	// Returns polynomial x multiplied by polynomial y modulo the generator polynomial.
 	private static long multiplyMod(long x, long y) {
 		// Russian peasant multiplication algorithm
@@ -149,8 +149,8 @@ public class forcecrc32 {
 		}
 		return z;
 	}
-	
-	
+
+
 	// Returns polynomial x to the power of natural number y modulo the generator polynomial.
 	private static long powMod(long x, long y) {
 		// Exponentiation by squaring
@@ -163,15 +163,15 @@ public class forcecrc32 {
 		}
 		return z;
 	}
-	
-	
+
+
 	// Computes polynomial x divided by polynomial y, returning the quotient and remainder.
 	private static long[] divideAndRemainder(long x, long y) {
 		if (y == 0)
 			throw new IllegalArgumentException("Division by zero");
 		if (x == 0)
 			return new long[]{0, 0};
-		
+
 		int ydeg = getDegree(y);
 		long z = 0;
 		for (int i = getDegree(x) - ydeg; i >= 0; i--) {
@@ -182,8 +182,8 @@ public class forcecrc32 {
 		}
 		return new long[]{z, x};
 	}
-	
-	
+
+
 	// Returns the reciprocal of polynomial x with respect to the generator polynomial.
 	private static long reciprocalMod(long x) {
 		// Based on a simplification of the extended Euclidean algorithm
@@ -204,10 +204,10 @@ public class forcecrc32 {
 		else
 			throw new IllegalArgumentException("Reciprocal does not exist");
 	}
-	
-	
+
+
 	private static int getDegree(long x) {
 		return 63 - Long.numberOfLeadingZeros(x);
 	}
-	
+
 }

--- a/forcing-a-files-crc-to-any-value/forcecrc32.py
+++ b/forcing-a-files-crc-to-any-value/forcecrc32.py
@@ -1,7 +1,7 @@
-# 
+#
 # CRC-32 forcer (Python)
 # Compatible with Python 2 and 3.
-# 
+#
 # Copyright (c) 2016 Project Nayuki
 # https://www.nayuki.io/page/forcing-a-files-crc-to-any-value
 #
@@ -12,16 +12,16 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program (see COPYING.txt).
 # If not, see <http://www.gnu.org/licenses/>.
-# 
+#
 
 import os, sys, zlib
 
@@ -47,7 +47,7 @@ def main(args):
         new_crc = reverse32(temp)
     except ValueError:
         return "Error: Invalid new CRC-32 value"
-    
+
     # Process the file
     try:
         raf = open(args[0], "r+b")
@@ -56,15 +56,15 @@ def main(args):
             length = raf.tell()
             if offset + 4 > length:
                 return "Error: Byte offset plus 4 exceeds file length"
-            
+
             # Read entire file and calculate original CRC-32 value
             crc = get_crc32(raf)
             print("Original CRC-32: {:08X}".format(reverse32(crc)))
-            
+
             # Compute the change to make
             delta = crc ^ new_crc
             delta = multiply_mod(reciprocal_mod(pow_mod(2, (length - offset) * 8)), delta)
-            
+
             # Patch 4 bytes in the file
             raf.seek(offset)
             bytes4 = bytearray(raf.read(4))
@@ -75,13 +75,13 @@ def main(args):
             raf.seek(offset)
             raf.write(bytes4)
             print("Computed and wrote patch")
-            
+
             # Recheck entire file
             if get_crc32(raf) == new_crc:
                 print("New CRC-32 successfully verified")
             else:
                 return "Error: Failed to update CRC-32 to desired value"
-        
+
         except IOError as e:
             return "Error: I/O error"
         finally:
@@ -149,7 +149,7 @@ def divide_and_remainder(x, y):
         raise ValueError("Division by zero")
     if x == 0:
         return (0, 0)
-    
+
     ydeg = get_degree(y)
     z = 0
     for i in range(get_degree(x) - ydeg, -1, -1):

--- a/forcing-a-files-crc-to-any-value/forcecrc32.py
+++ b/forcing-a-files-crc-to-any-value/forcecrc32.py
@@ -4,7 +4,10 @@
 # 
 # Copyright (c) 2016 Project Nayuki
 # https://www.nayuki.io/page/forcing-a-files-crc-to-any-value
-# 
+#
+# Copyright (c) 2016 Elliott Mitchell
+# Modification of reverse32()
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -105,12 +108,12 @@ def get_crc32(raf):
             crc = zlib.crc32(buffer, crc)
 
 
-def reverse32(x):
-    y = 0
-    for i in range(32):
-        y = (y << 1) | (x & 1)
-        x >>= 1
-    return y
+def reverse32(v):
+	# blitter-type solution, rather faster than the naive solution
+	masks = 0x55555555, 0x33333333, 0xF0F0F0F, 0xFF00FF, 0xFFFF
+	for s in range(len(masks)):
+		v = ((v >> (1<<s)) & masks[s]) | ((v & masks[s]) << (1<<s))
+	return v
 
 
 # ---- Polynomial arithmetic ----

--- a/forcing-a-files-crc-to-any-value/forcecrc32main.c
+++ b/forcing-a-files-crc-to-any-value/forcecrc32main.c
@@ -1,6 +1,6 @@
-/* 
+/*
  * CRC-32 forcer (C)
- * 
+ *
  * Copyright (c) 2016 Project Nayuki
  * https://www.nayuki.io/page/forcing-a-files-crc-to-any-value
  *
@@ -12,12 +12,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program (see COPYING.txt).
  * If not, see <http://www.gnu.org/licenses/>.

--- a/forcing-a-files-crc-to-any-value/forcecrc32main.c
+++ b/forcing-a-files-crc-to-any-value/forcecrc32main.c
@@ -6,7 +6,7 @@
  *
  * Copyright (c) 2016 Elliott Mitchell
  * Creation this file from portion of Project Nayuki forcecrc32.c file.
- * Modification of get_crc32_and_length().
+ * Modification of get_crc32_and_length() and modification of reverse_bits()
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -183,12 +183,14 @@ static void fseek64(FILE *f, uint64_t offset) {
 
 
 #ifdef DISABLE_ZLIB
-static uint32_t reverse_bits(uint32_t x) {
-	uint32_t result = 0;
-	int i;
-	for (i = 0; i < 32; i++)
-		result = (result << 1) | ((x >> i) & 1);
-	return result;
+static uint32_t reverse_bits(uint32_t val) {
+	int s;
+	// blitter-type solution, rather faster than the naive solution
+	const uint32_t masks[] = {0x55555555, 0x33333333, 0xF0F0F0F, 0xFF00FF, 0xFFFF};
+	for (s = 0; s<sizeof(masks)/sizeof(masks[0]); ++s)
+		val = ((val >> (1<<s)) & masks[s]) | ((val & masks[s]) << (1<<s));
+
+	return val;
 }
 #endif
 

--- a/forcing-a-files-crc-to-any-value/forcecrc32main.c
+++ b/forcing-a-files-crc-to-any-value/forcecrc32main.c
@@ -1,0 +1,181 @@
+/* 
+ * CRC-32 forcer (C)
+ * 
+ * Copyright (c) 2016 Project Nayuki
+ * https://www.nayuki.io/page/forcing-a-files-crc-to-any-value
+ *
+ * Copyright (c) 2016 Elliott Mitchell
+ * Creation this file from portion of Project Nayuki forcecrc32.c file.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program (see COPYING.txt).
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <inttypes.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "forcecrc32.h"
+
+
+/* Forward declarations */
+
+static uint32_t get_crc32_and_length(FILE *f, uint64_t *length);
+static void fseek64(FILE *f, uint64_t offset);
+static uint32_t reverse_bits(uint32_t x);
+
+
+/* Main program */
+
+int main(int argc, char **argv) {
+	// Handle arguments
+	if (argc != 4) {
+		fprintf(stderr, "Usage: %s FileName ByteOffset NewCrc32Value\n", argv[0]);
+		return EXIT_FAILURE;
+	}
+
+	// Parse and check file offset argument
+	uint64_t offset;
+	if (sscanf(argv[2], "%" SCNu64, &offset) != 1) {
+		fprintf(stderr, "Error: Invalid byte offset\n");
+		return EXIT_FAILURE;
+	}
+	char temp[21] = {0};
+	sprintf(temp, "%" PRIu64, offset);
+	if (strcmp(temp, argv[2]) != 0) {
+		fprintf(stderr, "Error: Invalid byte offset\n");
+		return EXIT_FAILURE;
+	}
+
+	// Parse and check new CRC argument
+	uint32_t newcrc;
+	if (strlen(argv[3]) != 8 || argv[3][0] == '+' || argv[3][0] == '-'
+			|| sscanf(argv[3], "%" SCNx32, &newcrc) != 1) {
+		fprintf(stderr, "Error: Invalid new CRC-32 value\n");
+		return EXIT_FAILURE;
+	}
+	newcrc = reverse_bits(newcrc);
+
+	// Process the file
+	FILE *f = fopen(argv[1], "r+b");
+	if (f == NULL) {
+		perror("fopen");
+		return EXIT_FAILURE;
+	}
+
+	// Read entire file and calculate original CRC-32 value.
+	// Note: We can't use fseek(f, 0, SEEK_END) + ftell(f) to determine the length of the file, due to undefined behavior.
+	// To be portable, we also avoid using POSIX fseeko()+ftello() or Windows GetFileSizeEx()/_filelength().
+	uint64_t length;
+	uint32_t crc = get_crc32_and_length(f, &length);
+	if (offset > UINT64_MAX - 4 || offset + 4 > length) {
+		fprintf(stderr, "Error: Byte offset plus 4 exceeds file length\n");
+		return EXIT_FAILURE;
+	}
+	fprintf(stdout, "Original CRC-32: %08" PRIX32 "\n", reverse_bits(crc));
+
+	// Compute the change to make
+	uint32_t delta = reverse_crc32(crc ^ newcrc, length - offset);
+
+	// Patch 4 bytes in the file
+	fseek64(f, offset);
+	int i;
+	for (i = 0; i < 4; i++) {
+		int b = fgetc(f);
+		if (b == EOF) {
+			perror("fgetc");
+			return EXIT_FAILURE;
+		}
+		b ^= (int)((delta >> (i * 8)) & 0xFF);
+		if (fseek(f, -1, SEEK_CUR) != 0) {
+			perror("fseek");
+			return EXIT_FAILURE;
+		}
+		if (fputc(b, f) == EOF) {
+			perror("fputc");
+			return EXIT_FAILURE;
+		}
+	}
+	fprintf(stdout, "Computed and wrote patch\n");
+
+	// Recheck entire file
+	if (get_crc32_and_length(f, &length) == newcrc) {
+		fprintf(stdout, "New CRC-32 successfully verified\n");
+		fclose(f);
+		return EXIT_SUCCESS;
+	} else {
+		fprintf(stderr, "Error: Failed to update CRC-32 to desired value\n");
+		return EXIT_FAILURE;
+	}
+}
+
+
+/* Utilities */
+
+static const uint64_t POLYNOMIAL = UINT64_C(0x104C11DB7);  // Generator polynomial. Do not modify, because there are many dependencies
+
+
+static uint32_t get_crc32_and_length(FILE *f, uint64_t *length) {
+	rewind(f);
+	uint32_t crc = UINT32_C(0xFFFFFFFF);
+	*length = 0;
+	while (true) {
+		char buffer[32 * 1024];
+		size_t n = fread(buffer, 1, sizeof(buffer), f);
+		if (ferror(f) != 0) {
+			perror("fread");
+			exit(EXIT_FAILURE);
+		}
+		size_t i;
+		for (i = 0; i < n; i++) {
+			int j;
+			for (j = 0; j < 8; j++) {
+				int bit = ((uint8_t)buffer[i] >> j) & 1;
+				crc ^= (uint32_t)bit << 31;
+				int xor = crc >> 31;  // Boolean
+				crc = (crc & UINT32_C(0x7FFFFFFFF)) << 1;
+				if (xor)
+					crc ^= (uint32_t)POLYNOMIAL;
+			}
+		}
+		*length += n;
+		if (feof(f))
+			return ~crc;
+	}
+}
+
+
+static void fseek64(FILE *f, uint64_t offset) {
+	rewind(f);
+	while (offset > 0) {
+		long n = LONG_MAX;
+		if (offset < (unsigned long)n)
+			n = (long)offset;
+		fseek(f, n, SEEK_CUR);
+		offset -= (unsigned long)n;
+	}
+}
+
+
+static uint32_t reverse_bits(uint32_t x) {
+	uint32_t result = 0;
+	int i;
+	for (i = 0; i < 32; i++)
+		result = (result << 1) | ((x >> i) & 1);
+	return result;
+}
+

--- a/forcing-a-files-crc-to-any-value/forcecrc32main.c
+++ b/forcing-a-files-crc-to-any-value/forcecrc32main.c
@@ -6,6 +6,7 @@
  *
  * Copyright (c) 2016 Elliott Mitchell
  * Creation this file from portion of Project Nayuki forcecrc32.c file.
+ * Modification of get_crc32_and_length().
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -68,7 +69,6 @@ int main(int argc, char **argv) {
 		fprintf(stderr, "Error: Invalid new CRC-32 value\n");
 		return EXIT_FAILURE;
 	}
-	newcrc = reverse_bits(newcrc);
 
 	// Process the file
 	FILE *f = fopen(argv[1], "r+b");
@@ -86,7 +86,7 @@ int main(int argc, char **argv) {
 		fprintf(stderr, "Error: Byte offset plus 4 exceeds file length\n");
 		return EXIT_FAILURE;
 	}
-	fprintf(stdout, "Original CRC-32: %08" PRIX32 "\n", reverse_bits(crc));
+	fprintf(stdout, "Original CRC-32: %08" PRIX32 "\n", crc);
 
 	// Compute the change to make
 	uint32_t delta = reverse_crc32(crc ^ newcrc, length - offset);
@@ -154,7 +154,7 @@ static uint32_t get_crc32_and_length(FILE *f, uint64_t *length) {
 		}
 		*length += n;
 		if (feof(f))
-			return ~crc;
+			return reverse_bits(~crc);
 	}
 }
 


### PR DESCRIPTION
Sorry, but I must suggest you remove commit 4e524fd20935ddb0c8b4e7f01f6a776d91051e07 and then take these commits instead.  4e524fd20935ddb0c8b4e7f01f6a776d91051e07 has some utility value, but a tiny fraction of what these commits have.

First, the point of placing main() in a separate file is someone wanting to reuse the code can then simply copy forcecrc32.c and forcecrc32.h into their project and call the appropriate function.  Whereas to reuse forcecrc32.c the way you have it, one **MUST** delete main() and modify at least one function declaration to mark it extern.

Second, the way you've modified things you're imposing a large number of assumptions which had been very **deliberately** removed from my modifications.  Depending upon what other software was in use, the existing CRC might already be readily available and recomputing it can be expensive if you're working with gigabyte-sized files.  Crucially your code _assumes_ someone wants to modify the CRC of a _file_, meanwhile in some cases (such as mine) one is working with data which is _already_ in memory and I merely need to know how to modify the data to get the desired CRC and no whole files will ever be touched.

Third, if someone is modifying CRCs on a batch of files (the only way your functions can be used) then performance could be a big deal and the faster CRC and bit reversal functions are highly valuable.