### PR TITLE
Fix for rare conditions of almost identical points leading to numerical problems

### DIFF
--- a/smallest-enclosing-circle/smallestenclosingcircle.py
+++ b/smallest-enclosing-circle/smallestenclosingcircle.py
@@ -112,10 +112,11 @@ def make_diameter(p0, p1):
 	return (cx, cy, max(r0, r1))
 
 
-_MULTIPLICATIVE_EPSILON = 1 + 1e-14
+_EPSILON = 1e-14
+_MULTIPLICATIVE_EPSILON = 1 + _EPSILON
 
 def is_in_circle(c, p):
-	return c is not None and math.hypot(p[0] - c[0], p[1] - c[1]) <= c[2] * _MULTIPLICATIVE_EPSILON
+    return c is not None and math.hypot(p[0] - c[0], p[1] - c[1]) <= max(c[2] * _MULTIPLICATIVE_EPSILON, c[2] + _EPSILON)
 
 
 # Returns twice the signed area of the triangle defined by (x0, y0), (x1, y1), (x2, y2).


### PR DESCRIPTION
Integrated your updated code in our system. Indeed problems are much more rare now, but still happen in some extreme cases where 2 points are **almost** the same but not exactly. 
For example:
[(28.574673225992726, -71.46163026530454), (28.57467502647469, -71.46162939333391), (28.57473666698254, -71.46164951956116), (28.574673225992726, -71.46163026530452)]

Made a small change to your epsilon condition using the max between a multiplicative epsilon and an additive epsilon. This seems to handle all cases properly.

(Opening a new PR since I erased the previous commit and therefore can't reopen PR #3)

